### PR TITLE
Update setup.py, add exclude for "tests"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     url="https://github.com/bieniu/accuweather",
     license="Apache License 2.0",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     python_requires=">=3.6",
     install_requires=list(val.strip() for val in open("requirements.txt")),
     classifiers=[


### PR DESCRIPTION
otherwise it tries to install a package "tests" at top level:

```
>>> Emerging (1 of 1) dev-python/accuweather-0.1.0::HomeAssistantRepository
>>> Failed to emerge dev-python/accuweather-0.1.0, Log file:
>>>  '/var/tmp/portage/dev-python/accuweather-0.1.0/temp/build.log'
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.84, 0.64, 0.61
 * Package:    dev-python/accuweather-0.1.0
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   maciej.bieniek@gmail.com
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_8 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking accuweather-0.1.0.tar.gz to /var/tmp/portage/dev-python/accuweather-0.1.0/work
>>> Source unpacked in /var/tmp/portage/dev-python/accuweather-0.1.0/work
>>> Preparing source in /var/tmp/portage/dev-python/accuweather-0.1.0/work/accuweather-0.1.0 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/accuweather-0.1.0/work/accuweather-0.1.0 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/accuweather-0.1.0/work/accuweather-0.1.0 ...
 * python3_8: running distutils-r1_run_phase distutils-r1_python_compile
removing /var/tmp/portage/dev-python/accuweather-0.1.0/temp/tmpgxr36xow.py
running install_egg_info
running egg_info
writing accuweather.egg-info/PKG-INFO
writing dependency_links to accuweather.egg-info/dependency_links.txt
writing requirements to accuweather.egg-info/requires.txt
writing top-level names to accuweather.egg-info/top_level.txt
reading manifest file 'accuweather.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'accuweather.egg-info/SOURCES.txt'
Copying accuweather.egg-info to /var/tmp/portage/dev-python/accuweather-0.1.0/image/_python3.8/usr/lib/python3.8/site-packages/accuweather-0.1.0-py3.8.egg-info
running install_scripts
 * ERROR: dev-python/accuweather-0.1.0::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system
```